### PR TITLE
Adding advanced features: exit built-in with arguments and handle Ctrl+C

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,7 @@
+- 'EOH'
 # This file lists all individuals having contributed content to the repository.
+# For how it is generated, see `hack/generate-authors.sh`.
 
-Daniela Lopera <1469@holbertonschool.com>
-Diana Carolina Quintero Caro <karodev3@gmail.com>
+daniela <1469@holbertonschool.com>
+danielaloperahernandez <1469@holbertonschool.com>
+KaroDev3 <karodev3@gmail.com>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ The Simple Shell is a simple UNIX command interpreter written in C. The program 
 All of the ``.c`` files along with a main.c file are to be compiled with ``gcc 4.8.4`` on Ubuntu 14.04 LTS with the flags ``-Wall Werror`` ``-Wextra`` and ``-pedantic.``
 The files will be compiled this way:
 - ``gcc -Wall -Werror -Wextra -pedantic *.c -o hsh``
+
+### Execute
+```{bash}
+$ ./hsh
+```
+
 ### Usage
 The shell works like this in interactive mode:
 
@@ -55,8 +61,8 @@ execute_line.c  list_path.c  README.md           special_case.c  _which.c
 $
 ```
 ```{bash}
-$ echo "non-interactive" | /bin/sh
-/bin/sh: 1: non-interactive: not found
+$ echo "non-interactive" | ./hsh
+./hsh: 1: non-interactive: not found
 $
 ```
 ### Built-ins

--- a/built_in.c
+++ b/built_in.c
@@ -50,14 +50,15 @@ void built_exit(char *line, char **commands, int *exit_st)
 	int num = 0;
 
 	free(line);
-	if (commands[1] && num_is_positive(commands[1]) == 0)
+	if (commands[1])
 	{
-		num = _atoi(commands[1]);
-		*exit_st = num;
-	}
-	else if (num_is_positive(commands[1]) == -1)
-	{
-		write(1, "Ilegal number\n", 14);
+		if (num_is_positive(commands[1]) == 0)
+		{
+			num = _atoi(commands[1]);
+			*exit_st = num;
+		}
+		else
+			write(1, "Ilegal number\n", 14);
 	}
 	free_loop(commands);
 	exit(*exit_st);

--- a/built_in.c
+++ b/built_in.c
@@ -1,4 +1,44 @@
 #include "shell.h"
+#include  <ctype.h>
+#include <string.h>
+/**
+*num_is_positive - function that verify if a string is a positive number
+*@com: string to check
+*Return: 0 on success and -1 if is negative or is not a number
+*/
+int num_is_positive(char *com)
+{
+	int i = 0;
+
+	if (com[0] == '-')
+		return (-1);
+	for (i = 0; com[i]; i++)
+	if (com[i] <= '0' && com[i] >= '9')
+		return (-1);
+	return (0);
+}
+/**
+*_atoi - transform a char in an integer
+*@com: string to check
+*Return: the integer
+*/
+int _atoi(char *com)
+{
+	int n = 0, sign = 1, result = 0;
+
+	for (n = result = 0; com[n]; n++)
+	{
+		if (com[n] == '-')
+			sign *= -1;
+		if (com[n] >= '0' && com[n] <= '9')
+			result = 10 * result - (com[n] - '0');
+		if (result < 0 && (com[n] < '0' || com[n] > '9'))
+			break;
+	}
+	if (sign > 0)
+		result *= -1;
+	return (result);
+}
 /**
 *built_exit - function that implement the exit builtin
 *@line: the buffer
@@ -7,7 +47,18 @@
 */
 void built_exit(char *line, char **commands, int *exit_st)
 {
+	int num = 0;
+
 	free(line);
+	if (commands[1] && num_is_positive(commands[1]) == 0)
+	{
+		num = _atoi(commands[1]);
+		*exit_st = num;
+	}
+	else if (num_is_positive(commands[1]) == -1)
+	{
+		write(1, "Ilegal number\n", 14);
+	}
 	free_loop(commands);
 	exit(*exit_st);
 }

--- a/list_path.c
+++ b/list_path.c
@@ -37,6 +37,8 @@ list_p *list_path(char **env)
 
 	head = NULL;
 	path = _getenv("PATH", env);
+	if (path[0] == ':')
+		add_node_end(&head, ".");
 	token = strtok(path, ":");
 	while (token != NULL)
 	{

--- a/shell.c
+++ b/shell.c
@@ -1,5 +1,14 @@
 #include "shell.h"
 /**
+*INThandler - fuction invoked for a signal function and show the prompt
+*@sig_n: number of the signal
+*/
+void INThandler(int sig_n)
+{
+	(void)sig_n;
+	write(STDOUT_FILENO, "\n($) ", 5);
+}
+/**
 *main - Program that is a simple UNIX command interpreter
 *@argc: argument count
 *@argv: argument char-pointers array
@@ -19,6 +28,7 @@ int main(int argc, char **argv, char **env)
 	{
 		if (isatty(fileno(stdin)))
 			write(1, "($) ", 4);
+		signal(SIGINT, INThandler);
 		line_len = getline(&line, &bufsize, stdin);
 		count++;
 		if (special_case(line, line_len, &exit_st) == 3)


### PR DESCRIPTION
- Handle arguments for the built-in exit --built_in.c
Usage: exit [status], where status is an integer used to exit the shell.

- Handle Ctrl+C: your shell should not quit when the user inputs ^C --shell.c

- Adding the current directory to the PATH --list_path.c