### PR TITLE
Fixing memory leaks

### DIFF
--- a/_which.c
+++ b/_which.c
@@ -8,23 +8,27 @@
 char *_which(char **commands, char **env)
 {
 	list_p *head;
+	list_p *aux;
+	char *first_part = NULL;
 	char *full_path = NULL;
+	char *final_path = NULL;
 	struct stat st;
 
 	head = list_path(env);
-	while (head)
+	aux = head;
+	while (aux)
 	{
-		full_path = _strcat(head->dir, "/");
-		full_path = _strcat(full_path, commands[0]);
-
+		first_part = _strcat(aux->dir, "/");
+		full_path = _strcat(first_part, commands[0]);
+		free(first_part);
 		if (stat(full_path, &st) == 0)
+		{
+			final_path = full_path;
 			break;
-		head = head->next;
+		}
+		free(full_path);
+		aux = aux->next;
 	}
-	if (full_path == NULL)
-	{
-		perror("");
-		return (NULL);
-	}
-	return (full_path);
+	free_list(head);
+	return (final_path);
 }

--- a/execute_line.c
+++ b/execute_line.c
@@ -8,12 +8,12 @@
 *@exit_st: exit status
 */
 void execute_line(char **argv, char **commands, int count,
-char **env, int *exit_st)
+		  char **env, int *exit_st, char *line)
 {
 	pid_t pid;
 	int status;
-	char *full_path;
-
+	char *full_path = NULL;
+	(void)line;
 	pid = fork();
 	if (pid < 0)
 		perror("Error:");
@@ -22,18 +22,24 @@ char **env, int *exit_st)
 		full_path = commands[0];
 		if (**commands != '/')
 			full_path = _which(commands, env);
-
-		if (access(full_path, X_OK) == 0)
+		if (full_path)
 		{
-			execve(full_path, commands, env);
+			printf("%s", full_path);
+			if (access(full_path, X_OK) == 0)
+			{
+				execve(full_path, commands, env);
+			}
+			free(full_path);
 		}
 		_error(argv, commands[0], count, &exit_st);
+		free_loop(commands);
+		free(line);
 		exit(*exit_st);
 	}
 	else
 	{
 		wait(&status);
-		*exit_st = WEXITSTATUS(status);
 		free_loop(commands);
+		*exit_st = WEXITSTATUS(status);
 	}
 }

--- a/free_loop.c
+++ b/free_loop.c
@@ -11,3 +11,20 @@ void free_loop(char **arr)
 		free(arr[len]);
 	free(arr);
 }
+
+/**
+ *free_listint - frees a listint_t list
+ *@head: head of a listint_t list
+ */
+void free_list(list_p *head)
+{
+	list_p *prev;
+
+	while (head)
+	{
+		free(head->dir);
+		prev = head;
+		head = head->next;
+		free(prev);
+	}
+}

--- a/list_path.c
+++ b/list_path.c
@@ -5,13 +5,11 @@
  *@dir: string to initialize new node
  *Return: new or NULL
  */
-list_p *add_node_end(list_p **head, const char *dir)
+void add_node_end(list_p **head, const char *dir)
 {
 	list_p *last = *head;
 	list_p *new = malloc(sizeof(list_p));
 
-	if (new == NULL)
-		return (NULL);
 	new->next = NULL;
 	new->dir = _strdup((char *)dir);
 	if (last)
@@ -22,7 +20,6 @@ list_p *add_node_end(list_p **head, const char *dir)
 	}
 	else
 		*head = new;
-	return (new);
 }
 /**
  *list_path - function that builds a linked list of the PATH directories

--- a/shell.c
+++ b/shell.c
@@ -41,7 +41,7 @@ int main(int argc, char **argv, char **env)
 		else if (_strcmp("env", *commands) == 0)
 			built_env(commands, env);
 		else
-			execute_line(argv, commands, count, env, &exit_st);
+			execute_line(argv, commands, count, env, &exit_st, line);
 		fflush(stdin);
 	}
 	free(line);

--- a/shell.h
+++ b/shell.h
@@ -25,7 +25,7 @@ typedef struct list_path
 
 /*Functions of the shell*/
 void execute_line(char **argv, char **commands, int count,
-char **env, int *exit_st);
+		  char **env, int *exit_st, char *line);
 char **split_line(char *line);
 list_p *list_path(char **env);
 int _setenv(const char *name, const char *value, int overwrite);
@@ -38,10 +38,11 @@ int special_case(char *line, ssize_t line_len, int *exit_st);
 
 /*useful functions*/
 int _strlen(char *s);
-list_p *add_node_end(list_p **head, const char *str);
+void add_node_end(list_p **head, const char *str);
 char *_strcat(char *s1, char *s2);
 char *_strdup(char *str);
 int _strcmp(char *s1, char *s2);
 void free_loop(char **arr);
+void free_list(list_p *head);
 char *_strncpy(char *dest, char *src, int n);
 #endif /* SHELL_H*/


### PR DESCRIPTION
Free memory when use _strcat function --_which.c
Free memory before exits the child process --execute_line.c
Creating free_list function --free_loop.c
Updating add_node_end prototype --list_path.c
Sending the buffer line to execute_line function --shell.c
Updating protypes of execute_line.c and add_node_end --shell.h