### PR TITLE
Illegal free was removed --execute_line.c

### DIFF
--- a/execute_line.c
+++ b/execute_line.c
@@ -26,10 +26,7 @@ void execute_line(char **argv, char **commands, int count,
 		if (full_path)
 		{
 			if (access(full_path, X_OK) == 0)
-			{
 				execve(full_path, commands, env);
-			}
-			free(full_path);
 		}
 		_error(argv, commands[0], count, &exit_st);
 		free_loop(commands);


### PR DESCRIPTION
Illegal free was removed, since it generates errors when entering the hsh prompt a path that doesn't exist --execute_line.c