### PR TITLE
Eliminating illegal functions

### DIFF
--- a/built_in.c
+++ b/built_in.c
@@ -67,15 +67,18 @@ void built_exit(char *line, char **commands, int *exit_st)
 *built_env - function that implement the env builtin
 *@commands: the split arguments
 *@env: the environment
+*@exit_st: the exit status
 */
-void built_env(char **commands, char **env)
+void built_env(char **commands, char **env, int *exit_st)
 {
 	char **aux = env;
 
 	while (*aux != NULL)
 	{
-		printf("%s\n", *aux);
+		write(1, *aux, _strlen(*aux));
+		write(1, "\n", 1);
 		aux++;
 	}
+	*exit_st = 0;
 	free_loop(commands);
 }

--- a/shell.c
+++ b/shell.c
@@ -39,7 +39,7 @@ int main(int argc, char **argv, char **env)
 		if (_strcmp("exit", *commands) == 0)
 			built_exit(line, commands, &exit_st);
 		else if (_strcmp("env", *commands) == 0)
-			built_env(commands, env);
+			built_env(commands, env, &exit_st);
 		else
 			execute_line(argv, commands, count, env, &exit_st, line);
 		fflush(stdin);

--- a/shell.h
+++ b/shell.h
@@ -31,7 +31,7 @@ list_p *list_path(char **env);
 int _setenv(const char *name, const char *value, int overwrite);
 char *_which(char **commands, char **env);
 void built_exit(char *line, char **arg, int *exit_st);
-void built_env(char **arg, char **env);
+void built_env(char **arg, char **env, int *exit_st);
 char *_getenv(const char *name, char **env);
 void _error(char **argv, char *first, int count, int **exit_st);
 int special_case(char *line, ssize_t line_len, int *exit_st);

--- a/special_case.c
+++ b/special_case.c
@@ -10,13 +10,13 @@
 */
 int special_case(char *line, ssize_t line_len, int *exit_st)
 {
-	if (line_len == -1 && isatty(fileno(stdin)))
+	if (line_len == -1 && isatty(STDIN_FILENO) == 1)
 	{
 		write(1, "\n", 1);
 		free(line);
 		exit(*exit_st);
 	}
-	if (line_len == -1 && !isatty(fileno(stdin)))
+	if (line_len == -1 && isatty(STDIN_FILENO) == 0)
 	{
 		free(line);
 		exit(*exit_st);


### PR DESCRIPTION
- Removing printf from built-in env --built_in.c
- Modifying the prototype to take into account the exit status int builtin env --built_in.c --shell.c --shell.h
- Replacing fileno with the fd STDIN_FILENO in the special_case function --special_case.c